### PR TITLE
Add support for TConstruct melting and casting

### DIFF
--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/block.json
@@ -1,0 +1,11 @@
+{
+  "type": "tconstruct:casting_basin",
+  "fluid": {
+    "tag": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 810
+  },
+  "result": {
+    "tag": "forge:storage_blocks/dragonsteel_fire"
+  },
+  "cooling_time": 194
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/ingot_gold_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/ingot_gold_cast.json
@@ -1,0 +1,14 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/multi_use/ingot"
+  },
+  "fluid": {
+    "tag": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_fire"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/ingot_sand_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_fire/ingot_sand_cast.json
@@ -1,0 +1,15 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/single_use/ingot"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "tag": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_fire"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/block.json
@@ -1,0 +1,11 @@
+{
+  "type": "tconstruct:casting_basin",
+  "fluid": {
+    "tag": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 810
+  },
+  "result": {
+    "tag": "forge:storage_blocks/dragonsteel_ice"
+  },
+  "cooling_time": 194
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/ingot_gold_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/ingot_gold_cast.json
@@ -1,0 +1,14 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/multi_use/ingot"
+  },
+  "fluid": {
+    "tag": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_ice"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/ingot_sand_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_ice/ingot_sand_cast.json
@@ -1,0 +1,15 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/single_use/ingot"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "tag": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_ice"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/block.json
@@ -1,0 +1,11 @@
+{
+  "type": "tconstruct:casting_basin",
+  "fluid": {
+    "tag": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 810
+  },
+  "result": {
+    "tag": "forge:storage_blocks/dragonsteel_lightning"
+  },
+  "cooling_time": 194
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/ingot_gold_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/ingot_gold_cast.json
@@ -1,0 +1,14 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/multi_use/ingot"
+  },
+  "fluid": {
+    "tag": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_lightning"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/ingot_sand_cast.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/casting/dragonsteel_lightning/ingot_sand_cast.json
@@ -1,0 +1,15 @@
+{
+  "type": "tconstruct:casting_table",
+  "cast": {
+    "tag": "tconstruct:casts/single_use/ingot"
+  },
+  "cast_consumed": true,
+  "fluid": {
+    "tag": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 90
+  },
+  "result": {
+    "tag": "forge:ingots/dragonsteel_lightning"
+  },
+  "cooling_time": 65
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/axes.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/axes.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_fire_axe"
+    },
+    {
+      "item": "iceandfire:dragonsteel_fire_pickaxe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 270,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/block.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:storage_blocks/dragonsteel_fire"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 810
+  },
+  "temperature": 1250,
+  "time": 221
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/boots.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/boots.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_fire_boots"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 360,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/chestplate.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/chestplate.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_fire_chestplate"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 720,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/helmet.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/helmet.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_fire_helmet"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 450,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/ingot.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/ingot.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:ingots/dragonsteel_fire"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 90
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/leggings.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/leggings.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_fire_leggings"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 630,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/shovel.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/shovel.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_fire_shovel"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 90,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/weapon.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_fire/weapon.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_fire_sword"
+    },
+    {
+      "item": "iceandfire:dragonsteel_fire_hoe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_fire_dragonsteel",
+    "amount": 180,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/axes.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/axes.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_ice_axe"
+    },
+    {
+      "item": "iceandfire:dragonsteel_ice_pickaxe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 270,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/block.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:storage_blocks/dragonsteel_ice"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 810
+  },
+  "temperature": 1250,
+  "time": 221
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/boots.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/boots.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_ice_boots"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 360,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/chestplate.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/chestplate.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_ice_chestplate"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 720,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/helmet.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/helmet.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_ice_helmet"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 450,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/ingot.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/ingot.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:ingots/dragonsteel_ice"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 90
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/leggings.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/leggings.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_ice_leggings"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 630,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/shovel.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/shovel.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_ice_shovel"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 90,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/weapon.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_ice/weapon.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_ice_sword"
+    },
+    {
+      "item": "iceandfire:dragonsteel_ice_hoe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_ice_dragonsteel",
+    "amount": 180,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/axes.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/axes.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_lightning_axe"
+    },
+    {
+      "item": "iceandfire:dragonsteel_lightning_pickaxe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 270,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/block.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/block.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:storage_blocks/dragonsteel_lightning"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 810
+  },
+  "temperature": 1250,
+  "time": 221
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/boots.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/boots.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_lightning_boots"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 360,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/chestplate.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/chestplate.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_lightning_chestplate"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 720,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/helmet.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/helmet.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_lightning_helmet"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 450,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/ingot.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/ingot.json
@@ -1,0 +1,12 @@
+{
+  "type": "tconstruct:melting",
+  "ingredient": {
+    "tag": "forge:ingots/dragonsteel_lightning"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 90
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/leggings.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/leggings.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_lightning_leggings"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 630,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/shovel.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/shovel.json
@@ -1,0 +1,13 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": {
+    "item": "iceandfire:dragonsteel_lightning_shovel"
+  },
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 90,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}

--- a/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/weapon.json
+++ b/src/main/resources/data/forgedinfire/recipes/smeltery/melting/metal/dragonsteel_lightning/weapon.json
@@ -1,0 +1,18 @@
+{
+  "type": "tconstruct:damagable_melting",
+  "ingredient": [
+    {
+      "item": "iceandfire:dragonsteel_lightning_sword"
+    },
+    {
+      "item": "iceandfire:dragonsteel_lightning_hoe"
+    }
+  ],
+  "result": {
+    "fluid": "forgedinfire:molten_lightning_dragonsteel",
+    "amount": 180,
+    "unit_size": 10
+  },
+  "temperature": 1250,
+  "time": 74
+}


### PR DESCRIPTION
Currently, if you have molten dragonsteel in a smeltery it is possible to cast it into tool parts. However, as far as I'm aware there is no way to add molten dragonsteel to the smeltery, or to cast it out into ingots or blocks. This PR fixes that by making it possible to melt some dragonsteel equipment in the smeltery, and to cast dragonsteel out into ingots or blocks from the smeltery.

Note: this PR does not add melting dragon armor into the smeltery, but that would probably be a good place to expand in the future.