### PR TITLE
Bring balance closer inline with base Ice & Fire

### DIFF
--- a/src/main/resources/data/forgedinfire/tinkering/materials/stats/dragon_bone.json
+++ b/src/main/resources/data/forgedinfire/tinkering/materials/stats/dragon_bone.json
@@ -1,0 +1,32 @@
+{
+  "stats": {
+    "tconstruct:skull": {
+      "durability": 4500,
+      "armor": 0
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 1.25,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 2.5,
+      "harvestTier": "minecraft:netherite",
+      "attack": 3.5
+    },
+    "tconstruct:limb": {
+      "durability": 200,
+      "drawSpeed": 0.07,
+      "velocity": -0.07,
+      "accuracy": 0.07
+    },
+    "tconstruct:grip": {
+      "durability": 1.0,
+      "accuracy": 0.15,
+      "meleeAttack": 1.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/materials/stats/dragon_scale.json
+++ b/src/main/resources/data/forgedinfire/tinkering/materials/stats/dragon_scale.json
@@ -1,0 +1,14 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 250
+    },
+    "tconstruct:extra": {},
+    "tconstruct:bowstring": {},
+    "tconstruct:grip": {
+      "durability": 1.1,
+      "accuracy": 0.25,
+      "meleeAttack": 3.0
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/materials/stats/fire_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/materials/stats/fire_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/materials/stats/ice_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/materials/stats/ice_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/materials/stats/lightning_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/materials/stats/lightning_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/dragon_bone.json
+++ b/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/dragon_bone.json
@@ -1,0 +1,32 @@
+{
+  "stats": {
+    "tconstruct:skull": {
+      "durability": 4500,
+      "armor": 0
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 1.25,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 2.5,
+      "harvestTier": "minecraft:netherite",
+      "attack": 3.5
+    },
+    "tconstruct:limb": {
+      "durability": 200,
+      "drawSpeed": 0.07,
+      "velocity": -0.07,
+      "accuracy": 0.07
+    },
+    "tconstruct:grip": {
+      "durability": 1.0,
+      "accuracy": 0.15,
+      "meleeAttack": 1.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/dragon_scale.json
+++ b/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/dragon_scale.json
@@ -1,0 +1,14 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 250
+    },
+    "tconstruct:extra": {},
+    "tconstruct:bowstring": {},
+    "tconstruct:grip": {
+      "durability": 1.1,
+      "accuracy": 0.25,
+      "meleeAttack": 3.0
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/fire_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/fire_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/ice_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/ice_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}

--- a/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/lightning_dragonsteel.json
+++ b/src/main/resources/data/forgedinfire/tinkering/modifiers/materials/stats/lightning_dragonsteel.json
@@ -1,0 +1,31 @@
+{
+  "stats": {
+    "tconstruct:repair_kit": {
+      "durability": 500
+    },
+    "tconstruct:extra": {},
+    "tconstruct:handle": {
+      "durability": 2.5,
+      "miningSpeed": 1.0,
+      "attackSpeed": 0.75,
+      "attackDamage": 1.0
+    },
+    "tconstruct:head": {
+      "durability": 4500,
+      "miningSpeed": 3.0,
+      "harvestTier": "minecraft:diamond",
+      "attack": 10.5
+    },
+    "tconstruct:limb": {
+      "durability": 400,
+      "drawSpeed": 0.25,
+      "velocity": 0.25,
+      "accuracy": 0.3
+    },
+    "tconstruct:grip": {
+      "durability": 2.0,
+      "accuracy": 0.25,
+      "meleeAttack": 2.5
+    }
+  }
+}


### PR DESCRIPTION
This PR brings the balance of dragonsteel and dragonbone closer to that set by the Ice and Fire mod itself. Note that this still undershoots a little bit because its based on my personal config values, but regardless it is closer to base.